### PR TITLE
Add optionals global configurations params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ This effectively eliminates the need for file watchers, and simplifies your buil
 
 ### How to use
 
-Create save-commands.json file in your project's root folder.
+Can set up with global configurations
+### Sample config.cson for global configurations
+```
+"save-commands":
+	"timeout": 5000,
+	commands: []
+```
+
+Create save-commands.json file in your project's root folder to override the global settings
 Create one entry for each command you wish to run, and assign it to a glob like this:  
 glob : command {parameter}
 

--- a/lib/atom-save-commands.coffee
+++ b/lib/atom-save-commands.coffee
@@ -178,15 +178,24 @@ module.exports = AtomSaveCommands =
 		@resultDiv.classList.add('save-result')
 		@panel.item.appendChild(@resultDiv)
 
+	tap: (o, fn) -> fn(o); o
+
+	merge: (xs...) ->
+	  if xs?.length > 0
+	    @tap {}, (m) -> m[k] = v for k, v of x for x in xs
+
 	loadConfig: (callback)->
 		confFile = atom.project.getPaths()[0] + path.sep + 'save-commands.json'
+
+		timeoutDuration = atom.config.get('save-commands.timeoutDuration')	# Load global configurations
+		saveCommands 		= atom.config.get('save-commands.saveCommands')
+		@config = {}
+		@config.timeout 	= timeoutDuration ? 4000
+		@config.commands	= saveCommands ? []
+
 		fs.readFile confFile, (err,data)=>
 			if data
-				@config = JSON.parse(data)
-			if err
-				@config =
-					timeout: 4000
-					commands: []
+				@config = @merge @config, JSON.parse(data)
 
 			@config.cwd ?= atom.project.getPaths()[0]
 

--- a/lib/atom-save-commands.coffee
+++ b/lib/atom-save-commands.coffee
@@ -187,11 +187,11 @@ module.exports = AtomSaveCommands =
 	loadConfig: (callback)->
 		confFile = atom.project.getPaths()[0] + path.sep + 'save-commands.json'
 
-		timeoutDuration = atom.config.get('save-commands.timeoutDuration')	# Load global configurations
-		saveCommands 		= atom.config.get('save-commands.saveCommands')
+		timeout 	= atom.config.get('save-commands.timeout')	# Load global configurations
+		commands 	= atom.config.get('save-commands.commands')
 		@config = {}
-		@config.timeout 	= timeoutDuration ? 4000
-		@config.commands	= saveCommands ? []
+		@config.timeout 	= timeout ? 4000
+		@config.commands	= commands ? []
 
 		fs.readFile confFile, (err,data)=>
 			if data


### PR DESCRIPTION
This pull request suggest to have a global configuration of the package's parameters that will be overwritten by the configuration in the local file save-commands.json in the root project folder.
