### PR TITLE
Support : in save commands, e.g. mvn war:exploded

### DIFF
--- a/lib/atom-save-commands.coffee
+++ b/lib/atom-save-commands.coffee
@@ -222,10 +222,12 @@ module.exports = AtomSaveCommands =
 
 			modCommands = []
 			for gc in @config.commands
-				kv = gc.split(':')
+				index = gc.indexOf(':')
+				g = gc.substring(0, index)
+				c = gc.substring(index + 1)
 				modCommands.push
-					glob: kv[0].trim()
-					command: kv[1].trim()
+					glob: g.trim()
+					command: c.trim()
 
 			@config.commands = modCommands
 			callback @config


### PR DESCRIPTION
`split("foo:bar:baz")` returns `["foo", "bar", "baz"]` so commands containing a `:` are truncated.
