### PR TITLE
When "suppressPanel" is enabled, show panel only on error

### DIFF
--- a/lib/atom-save-commands.coffee
+++ b/lib/atom-save-commands.coffee
@@ -104,8 +104,6 @@ module.exports = AtomSaveCommands =
 		cspr = spawn command, args ,
 			cwd: @config.cwd
 
-		@panel.show()
-
 		div = atom.views.getView(atom.workspace).getElementsByClassName('save-result')[0]
 		cspr.stdout.on 'data', (data)=>
 			# console.log "STD OUT: #{data}"
@@ -117,7 +115,7 @@ module.exports = AtomSaveCommands =
 
 		cspr.stderr.on 'data', (data)=>
 			# console.log "ERR OUT: #{data}"
-			# @panel.show()
+			@panel.show()
 			@hasError = true
 			dataDiv = document.createElement('div')
 			dataDiv.textContent = data.toString()


### PR DESCRIPTION
A stray @panel.show() appears to make the panel show up every time a command is executed, even if "Only display command output panel on error" is enabled in the package settings and no errors occur when running the script.
