### PR TITLE
Enhancements: define what constitutes an error + implement #33

### DIFF
--- a/lib/atom-save-commands.coffee
+++ b/lib/atom-save-commands.coffee
@@ -52,6 +52,11 @@ module.exports = AtomSaveCommands =
 			default: 'false'
 			title: 'Consider any data on `stderr` as an error, otherwise only rely on exit code of command'
 
+		configFileName:
+			type: 'string'
+			default: 'save-commands.json'
+			title: 'File name, relative to root of project, to use for configuration'
+
 	showError: (gc)->
 		epanel = atom.workspace.addBottomPanel(
 			item: document.createElement('div')
@@ -183,7 +188,7 @@ module.exports = AtomSaveCommands =
 			# console.log "Registered onSave event with '#{editor.getPath()}'"
 			@subscriptions.add editor.onDidSave (event)=>
 				try
-					@executeOn(event.path,'save-commands.json')
+					@executeOn(event.path,atom.config.get('save-commands.configFileName'))
 				catch error
 					console.log error
 


### PR DESCRIPTION
**Commit 157fff5**

Allow user to decide what constitutes an error when displaying the panel. For example, Python unittest will write to stderr even if all tests pass, and the exit status corresponds to failures.

An existing setting allows for suppression of output unless an error occurs, but it makes the assumption that any data received on stderr constitutes an error.

Implemented a second boolean setting that, if true, will ignore stderr and only rely on a non-zero exit code.

**Commit  f1d9f0a**
Addresses issue #33 with a general solution
